### PR TITLE
Creación Tickets Completa, subir una sola imagen

### DIFF
--- a/app/Http/Controllers/TicketsController.php
+++ b/app/Http/Controllers/TicketsController.php
@@ -46,6 +46,9 @@ class TicketsController extends Controller
 
     public function store(TicketRequest $request){
         
+        $request->validate([
+            'file' => 'required|image|max:2048'
+        ]);
         $treports = new ticket_reports();
         
         $date = Carbon::parse($request->date)->format('Y-m-d');

--- a/app/Http/Requests/TicketRequest.php
+++ b/app/Http/Requests/TicketRequest.php
@@ -24,8 +24,10 @@ class TicketRequest extends FormRequest
     public function rules()
     {
         return [
-            'date' => 'required|max:255'
-            
+            'date' => 'required|max:255',
+            'date_finish' => 'required',
+            'ticket_report' => 'required',
+            'employer' => 'required'
         ];
     }
 }

--- a/database/migrations/2021_12_27_003453_create_ticket_reports_table.php
+++ b/database/migrations/2021_12_27_003453_create_ticket_reports_table.php
@@ -16,8 +16,8 @@ class CreateTicketReportsTable extends Migration
         Schema::create('ticket_reports', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedBigInteger('user_report');
-            $table->date('date')->nullable();
-            $table->longText('ticket_report')->nullable();
+            $table->date('date');
+            $table->longText('ticket_report');
             $table->text('employer');
             $table->date('date_finish');
             $table->timestamps();

--- a/resources/views/tickets/create.blade.php
+++ b/resources/views/tickets/create.blade.php
@@ -1,6 +1,30 @@
 @extends('layouts.app')
 
 @section('content')
+@if (count($errors)>0)
+<div class="container">
+            <div class="row justify-content-center">
+                <div class="col-md-12">
+                    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+                        <div class="text-center">
+                            <strong>¡Parece que algunos campos estan vacios o no tienen los datos correctos!</strong>
+                        </div>
+                        <ul>
+                            @foreach ($errors->all() as $error)
+
+                                <li>{{ $error }}</li>
+
+                            @endforeach
+                        </ul>
+
+                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+</div>
+@endif
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-md-12">
@@ -41,6 +65,9 @@
                                 <div class="form-group">
                                     <label>Evidencia</label>
                                     <input type="file" id="file" name="file" accept="image/*">
+                                    @error('file')
+                                    <small class="text-danger">{{$message}}</small>
+                                    @enderror
                                 </div>
                             </div>
 


### PR DESCRIPTION
Se completa la sección de Creación Tickets
- Solo se puede subir una imagen
- No se muestran los archivos subidos o datos en la api, solo en la base de datos
- Todos los campos son requeridos y muestra mensaje
- Subir la imagen requiere que sea cualquier tipo de imagen, tanto front como backend